### PR TITLE
Add expanded unit tests

### DIFF
--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,41 @@
+import numpy as np
+import torch
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from dataloader import Data
+
+
+def create_npz(tmp_path):
+    coords = np.random.rand(4, 5, 3).astype(np.float32)
+    outputs = np.random.rand(4, 5, 5).astype(np.float32)
+    params = np.random.rand(4, 1).astype(np.float32)
+    path = tmp_path / "sample.npz"
+    np.savez(path, coords=coords, outputs=outputs, params=params)
+    return path
+
+
+def test_initialization(tmp_path):
+    npz = create_npz(tmp_path)
+    data = Data(str(npz))
+    assert data.coords.shape == (4, 5, 3)
+    assert data.outputs.shape == (4, 5, 5)
+    assert data.params.shape == (4, 1)
+
+
+def test_len_and_getitem(tmp_path):
+    npz = create_npz(tmp_path)
+    data = Data(str(npz))
+    assert len(data) == 4
+    c, p, o = data[1]
+    assert c.shape == (5, 3)
+    assert p.shape == (1,)
+    assert o.shape == (5, 5)
+
+
+def test_get_dataloader(tmp_path):
+    npz = create_npz(tmp_path)
+    data = Data(str(npz))
+    train, test = data.get_dataloader(batch_size=2, shuffle=False, test_size=0.5)
+    total = len(train.dataset) + len(test.dataset)
+    assert total == len(data)

--- a/tests/test_mlp_activation.py
+++ b/tests/test_mlp_activation.py
@@ -1,0 +1,26 @@
+import torch
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from model.MLP import MLP
+from model.activations import RowdyActivation
+
+
+def test_rowdy_activation_forward():
+    act = RowdyActivation(3, base_fn=torch.relu)
+    act.alpha.data.fill_(2.0)
+    x = torch.tensor([[-1.0, 0.5, 2.0]])
+    out = act(x)
+    expected = 2.0 * torch.relu(x)
+    assert torch.allclose(out, expected)
+
+
+def test_mlp_forward_and_hidden():
+    mlp = MLP(2, 3, 4, 2)
+    x = torch.randn(5, 2)
+    out = mlp(x)
+    assert out.shape == (5, 3)
+    out2, hidden = mlp.forward_with_outputs(x)
+    assert torch.allclose(out, out2)
+    assert len(hidden) == 2
+    assert hidden[0].shape[1] == 4

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,23 @@
+import torch
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from trainer import Trainer
+from model import FusionDeepONet
+
+
+def create_loaders():
+    coords = torch.rand(4, 5, 3)
+    params = torch.rand(4, 1)
+    outputs = torch.rand(4, 5, 5)
+    dataset = torch.utils.data.TensorDataset(coords, params, outputs)
+    loader = torch.utils.data.DataLoader(dataset, batch_size=2)
+    return loader
+
+
+def test_trainer_single_epoch():
+    loader = create_loaders()
+    model = FusionDeepONet(3, 1, 8, 2, 5)
+    trainer = Trainer(model, loader, device="cpu", lr=1e-3)
+    train_hist, test_hist = trainer.train(loader, loader, num_epochs=1, print_every=1)
+    assert len(train_hist) == len(test_hist) == 1


### PR DESCRIPTION
## Summary
- refactor preprocess tests to generate minimal example data and patch heavy sampling
- add new unit tests for Data dataloader
- cover MLP and RowdyActivation modules
- add basic Trainer test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431fc6e0308331bdacd29b16f2f824