### PR TITLE
Remove mask usage from training and data pipeline

### DIFF
--- a/dataloader/base_dataloader.py
+++ b/dataloader/base_dataloader.py
@@ -6,4 +6,3 @@ class BaseDataloader:
         self.coords = torch.tensor(data["coords"], dtype=torch.float32)    # (B, N, 3)
         self.outputs = torch.tensor(data["outputs"], dtype=torch.float32)  # (B, N, 4/5)
         self.params = torch.tensor(data["params"], dtype=torch.float32)    # (B, 1)
-        self.mask = torch.tensor(data["mask"], dtype=torch.bool)

--- a/dataloader/methods_dataloader.py
+++ b/dataloader/methods_dataloader.py
@@ -8,7 +8,7 @@ class MethodsDataloader:
         return self.coords.shape[0]  # number of samples
 
     def __getitem__(self, idx):
-        return self.coords[idx], self.params[idx], self.outputs[idx], self.mask[idx]
+        return self.coords[idx], self.params[idx], self.outputs[idx]
 
 
 
@@ -16,17 +16,16 @@ class MethodsDataloader:
         coords = self.coords
         outputs = self.outputs
         params = self.params
-        mask = self.mask
 
         # Split data into training and testing sets
         indices = np.arange(coords.shape[0])
         train_indices, test_indices = train_test_split(indices, test_size=test_size, shuffle=shuffle, random_state=42)
 
         train_dataset = torch.utils.data.TensorDataset(
-            coords[train_indices], params[train_indices], outputs[train_indices], mask[train_indices]
+            coords[train_indices], params[train_indices], outputs[train_indices]
         )
         test_dataset = torch.utils.data.TensorDataset(
-            coords[test_indices], params[test_indices], outputs[test_indices], mask[test_indices]
+            coords[test_indices], params[test_indices], outputs[test_indices]
         )
 
         train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)

--- a/preprocess/base_preprocess.py
+++ b/preprocess/base_preprocess.py
@@ -8,4 +8,3 @@ class BasePreprocess:
         self.npts_max = 0  # max elements determined based on data
         self.dimension = dimension
         self.lhs_applied = False
-        self.masks = []

--- a/preprocess/methods_preprocess.py
+++ b/preprocess/methods_preprocess.py
@@ -28,15 +28,13 @@ class MethodsPreprocess:
         padded_coords = []
         padded_radii = []
         padded_outputs = []
-        self.masks = []
         for c, r, o in zip(self.coords, self.radii, self.outputs):
-            c_pad, mask = self._pad(c)
-            r_pad, _ = self._pad(r)
-            o_pad, _ = self._pad(o)
+            c_pad = self._pad(c)
+            r_pad = self._pad(r)
+            o_pad = self._pad(o)
             padded_coords.append(c_pad)
             padded_radii.append(r_pad)
             padded_outputs.append(o_pad)
-            self.masks.append(mask)
 
         self.coords = padded_coords
         self.radii = padded_radii
@@ -83,28 +81,22 @@ class MethodsPreprocess:
     def _pad(self, arr):
         arr = np.asarray(arr)
         n_pad = self.npts_max - arr.shape[0]
-        mask = np.concatenate([
-            np.ones(arr.shape[0], dtype=bool),
-            np.zeros(n_pad, dtype=bool),
-        ])
         padded = np.pad(arr, ((0, n_pad), (0, 0)), mode="edge")
-        return padded, mask
+        return padded
 
     def to_numpy(self):
         X_coords = np.stack(self.coords)
         Y_outputs = np.stack(self.outputs)
         G_params = np.stack(self.radii)[:, 0, :]  # extract 1 value per sample
-        M_masks = np.stack(self.masks)
-        return X_coords, Y_outputs, G_params, M_masks
+        return X_coords, Y_outputs, G_params
 
     def save(self):
-        X_coords, Y_outputs, G_params, M_masks = self.to_numpy()
+        X_coords, Y_outputs, G_params = self.to_numpy()
         np.savez(
             self.output_path,
             coords=X_coords,           # shape: (num_samples, npts_max, 3)
             outputs=Y_outputs,         # shape: (num_samples, npts_max, output_dim)
             params=G_params,           # shape: (num_samples, 1)
-            mask=M_masks,
             coords_mean=self.coords_mean,     # shape: (3,)
             coords_std=self.coords_std,       # shape: (3,)
             outputs_mean=self.outputs_mean,   # shape: (output_dim,)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -10,9 +10,8 @@ def create_npz(tmp_path):
     coords = np.random.rand(4, 5, 3).astype(np.float32)
     outputs = np.random.rand(4, 5, 5).astype(np.float32)
     params = np.random.rand(4, 1).astype(np.float32)
-    mask = np.ones((4, 5), dtype=bool)
     path = tmp_path / "sample.npz"
-    np.savez(path, coords=coords, outputs=outputs, params=params, mask=mask)
+    np.savez(path, coords=coords, outputs=outputs, params=params)
     return path
 
 
@@ -22,18 +21,16 @@ def test_initialization(tmp_path):
     assert data.coords.shape == (4, 5, 3)
     assert data.outputs.shape == (4, 5, 5)
     assert data.params.shape == (4, 1)
-    assert data.mask.shape == (4, 5)
 
 
 def test_len_and_getitem(tmp_path):
     npz = create_npz(tmp_path)
     data = Data(str(npz))
     assert len(data) == 4
-    c, p, o, m = data[1]
+    c, p, o = data[1]
     assert c.shape == (5, 3)
     assert p.shape == (1,)
     assert o.shape == (5, 5)
-    assert m.shape == (5,)
 
 
 def test_get_dataloader(tmp_path):
@@ -50,7 +47,6 @@ def test_initialization_dtypes(tmp_path):
     assert data.coords.dtype == torch.float32
     assert data.outputs.dtype == torch.float32
     assert data.params.dtype == torch.float32
-    assert data.mask.dtype == torch.bool
 
 
 def test_getitem_returns_correct_values(tmp_path):
@@ -58,11 +54,10 @@ def test_getitem_returns_correct_values(tmp_path):
     raw = np.load(npz)
     data = Data(str(npz))
     idx = 2
-    c, p, o, m = data[idx]
+    c, p, o = data[idx]
     assert np.allclose(c.numpy(), raw['coords'][idx])
     assert np.allclose(o.numpy(), raw['outputs'][idx])
     assert np.allclose(p.numpy(), raw['params'][idx])
-    assert np.allclose(m.numpy(), raw['mask'][idx])
 
 
 def test_get_dataloader_split_sizes(tmp_path):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -86,18 +86,16 @@ def test_initial_state(preprocess):
     assert preprocess.radii == []
     assert preprocess.outputs == []
     assert preprocess.npts_max == 0
-    assert preprocess.masks == []
 
 
 def test_load_and_pad(preprocess):
     preprocess.load_and_pad()
     assert len(preprocess.coords) == 3
     assert preprocess.npts_max == TEST_SAMPLE_SIZE
-    for c, r, o, m in zip(preprocess.coords, preprocess.radii, preprocess.outputs, preprocess.masks):
+    for c, r, o in zip(preprocess.coords, preprocess.radii, preprocess.outputs):
         assert c.shape[0] == TEST_SAMPLE_SIZE
         assert r.shape[0] == TEST_SAMPLE_SIZE
         assert o.shape[0] == TEST_SAMPLE_SIZE
-        assert m.shape[0] == TEST_SAMPLE_SIZE
 
 
 def test_to_numpy_and_save(preprocess):
@@ -107,7 +105,6 @@ def test_to_numpy_and_save(preprocess):
     assert data["coords"].shape == (3, TEST_SAMPLE_SIZE, 3)
     assert data["outputs"].shape == (3, TEST_SAMPLE_SIZE, 5)
     assert data["params"].shape == (3, 1)
-    assert data["mask"].shape == (3, TEST_SAMPLE_SIZE)
 
     # arrays are normalized
     def check_norm(arr):
@@ -132,9 +129,8 @@ def test_pad_functionality():
     p = Preprocess(radius_files={}, dimension=3, output_path="out.npz")
     p.npts_max = 5
     arr = np.array([[1, 2], [3, 4], [5, 6]])
-    padded, mask = p._pad(arr)
+    padded = p._pad(arr)
     assert padded.shape == (5, 2)
-    assert mask.tolist() == [True, True, True, False, False]
     assert np.all(padded[3:] == arr[-1])
 
 
@@ -157,11 +153,10 @@ def test_lhs_applied_for_3d(preprocess):
 
 def test_to_numpy_shapes(preprocess):
     preprocess.load_and_pad()
-    coords, outputs, params, mask = preprocess.to_numpy()
+    coords, outputs, params = preprocess.to_numpy()
     assert coords.shape == (3, TEST_SAMPLE_SIZE, 3)
     assert outputs.shape == (3, TEST_SAMPLE_SIZE, 5)
     assert params.shape == (3, 1)
-    assert mask.shape == (3, TEST_SAMPLE_SIZE)
 
 
 def test_save_contains_statistics(preprocess, tmp_path):
@@ -178,7 +173,6 @@ def test_save_contains_statistics(preprocess, tmp_path):
         "radii_std",
     ]:
         assert key in data
-    assert data["mask"].dtype == np.bool_
 
 
 def test_run_all_dimension_2(radius_file_dict_2d, tmp_path):

--- a/trainer/methods_trainer.py
+++ b/trainer/methods_trainer.py
@@ -14,16 +14,14 @@ class MethodsTrainer:
             self.model.train()
             total_samples = 0
 
-            for coords, params, targets, mask in train_loader:
+            for coords, params, targets in train_loader:
                 coords = coords.to(self.device)
                 params = params.to(self.device)
                 targets = targets.to(self.device)
-                mask = mask.to(self.device)
 
                 self.optimizer.zero_grad()
                 outputs = self.model(coords, params)
-                diff = (outputs - targets) * mask.unsqueeze(-1)
-                loss = (diff ** 2).sum() / mask.sum()
+                loss = self.criterion(outputs, targets)
                 loss.backward()
                 self.optimizer.step()
 
@@ -51,15 +49,13 @@ class MethodsTrainer:
         total_loss = 0.0
         total_samples = 0
         with torch.no_grad():
-            for coords, params, targets, mask in dataloader:
+            for coords, params, targets in dataloader:
                 coords = coords.to(self.device)
                 params = params.to(self.device)
                 targets = targets.to(self.device)
-                mask = mask.to(self.device)
 
                 outputs = self.model(coords, params)
-                diff = (outputs - targets) * mask.unsqueeze(-1)
-                loss = (diff ** 2).sum() / mask.sum()
+                loss = self.criterion(outputs, targets)
                 batch_size = targets.size(0)
                 total_loss += loss.item() * batch_size
                 total_samples += batch_size


### PR DESCRIPTION
## Summary
- eliminate mask handling in preprocessing
- update dataloader to drop mask values
- simplify trainer loss calculation to plain MSE
- update corresponding tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684890d142248331abc26e33728ac3d0